### PR TITLE
increase parse-server version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "express": "^4.13.4",
-    "parse-server": "2.2.x",
+    "parse-server": "2.3.x",
     "parse-dashboard": "^1.0.11",
     "parse-server-azure-config": "^1.0.0"
   },


### PR DESCRIPTION
updating parse-server version as we have 2.3.X release available now
https://github.com/ParsePlatform/parse-server/releases 