### PR TITLE
Enable Parse Server 2.3 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
   },
   "license": "MIT",
   "dependencies": {
+    "buffer-shims": "^1.0.0",
     "express": "^4.13.4",
-    "parse-server": "2.2.x",
+    "parse-server": "2.3.x",
     "parse-dashboard": "^1.0.11",
     "parse-server-azure-config": "^1.0.0"
   },


### PR DESCRIPTION
looks like there's a weird npm issue where it fails to install the required `buffer-shims` dependency